### PR TITLE
Add clone traffic chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,3 +328,11 @@ Please follow PSR-12 coding standards. All new provider adapters must implement 
 ## License
 
 MIT — see [LICENSE](LICENSE).
+
+---
+
+## Clone traffic
+
+![Clone traffic](https://raw.githubusercontent.com/nikolareljin/stats/main/charts/nr-enrich-core.svg)
+
+_Updated daily. Total and unique cloners over the last 14 days._


### PR DESCRIPTION
## Summary

- Add the clone traffic SVG chart from nikolareljin/stats to the README.

## Validation

- Verified the stats SVG exists at charts/nr-enrich-core.svg before updating the README.
- Ran git diff --check for the README change.